### PR TITLE
Replace 'zing' user wtih a numeric username

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM traefik:1.4.6-alpine
 # development tools
 RUN apk add --no-cache bind-tools curl bash
 
-RUN addgroup -S traefik && adduser -S -g traefik traefik
-USER traefik
+RUN addgroup -S zing && adduser -S -G zing -u 512 512
+USER 512
 
 COPY ./traefik.toml /etc/traefik/traefik.toml
 


### PR DESCRIPTION
This PR replaces the `zing` USER with `512` for compatibility with k8s 1.9
K8S 1.9 will reject pods that have `securityContext.runAsNonRoot = true` when the USER in the container is a non-numeric value - https://github.com/kubernetes/kubernetes/pull/56503